### PR TITLE
Allow 'No Managed Code' as a valid runtime value for iis_pool

### DIFF
--- a/lib/puppet/type/iis_pool.rb
+++ b/lib/puppet/type/iis_pool.rb
@@ -39,11 +39,13 @@ Puppet::Type.newtype(:iis_pool) do
 
   newproperty(:runtime) do
     desc '.NET runtime version for the pool'
+    version_regex = %r{^v?\d+\.\d+$}
+    no_managed_code_regex = /^(no managed code|)$/i
     validate do |value|
-      raise("#{runtime} must be a float") unless value =~ %r{^v?\d+\.\d+$}
+      raise("#{runtime} must be a float") unless value =~ version_regex || value =~ no_managed_code_regex
     end
     munge do |value|
-      "v#{value.gsub(%r{^v}, '').to_f}"
+      value =~ version_regex ? "v#{value.gsub(%r{^v}, '').to_f}" : ''
     end
   end
 

--- a/spec/unit/puppet/type/iis_pool_spec.rb
+++ b/spec/unit/puppet/type/iis_pool_spec.rb
@@ -37,6 +37,15 @@ describe Puppet::Type.type(:iis_pool) do
     it 'munges runtime' do
       expect(subject(params.merge(runtime: '4.0'))[:runtime]).to eq('v4.0')
     end
+    it 'accepts No Managed Code and munges it to the empty string' do
+      expect(subject(params.merge(runtime: 'No Managed Code'))[:runtime]).to eq('')
+    end
+    it 'accepts the empty string for No Managed Code' do 
+      expect(subject(params.merge(runtime: ''))[:runtime]).to eq('')
+    end
+    it 'accepts case-insensitive No Managed Code' do 
+      expect(subject(params.merge(runtime: 'no ManaGeD coDe'))[:runtime]).to eq('')
+    end
   end
 
   describe 'pipeline =>' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

This change loosens the validation on the `runtime` property for the `iis_pool` resource type to module consumers to choose "No Managed Code", or no .NET runtime, for their application pool. The module consumer can specify this value one of two ways:

1.  The string "no managed code" (case-insensitive).
2.  The empty string.

If the property value matches either of these, the value will be munged to the empty string. 

This functionality is useful for running IIS as a reverse proxy server for .NET Core applications, which usually run in a separate process on a Kestrel server. The change fixes #163.